### PR TITLE
Remove unnecessary unwrapping.

### DIFF
--- a/src/unix/linux.rs
+++ b/src/unix/linux.rs
@@ -51,8 +51,8 @@ impl NetlinkSocket {
             address.nl_groups = RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR;
             let ptr = &mut address as *mut _;
             let mut size = size_of!(sockaddr_nl) as u32;
-            errno!(libc::bind(fd.as_raw_fd(), ptr as *mut _, size)).unwrap();
-            errno!(libc::getsockname(fd.as_raw_fd(), ptr as *mut _, &mut size)).unwrap();
+            errno!(libc::bind(fd.as_raw_fd(), ptr as *mut _, size))?;
+            errno!(libc::getsockname(fd.as_raw_fd(), ptr as *mut _, &mut size))?;
             let pid = address.nl_pid;
             address.nl_pid = 0;
             address.nl_groups = 0;
@@ -103,8 +103,7 @@ impl NetlinkSocket {
                     libc::MSG_NOSIGNAL,
                     address as _,
                     std::mem::size_of_val(&self.address) as _,
-                ))
-                .unwrap();
+                ))?;
                 Ok(())
             })
             .await


### PR DESCRIPTION
Relates to https://github.com/paritytech/substrate/issues/7794#issuecomment-753653887. While it is certainly desirable to investigate such failures further, not panicking seems like the right thing to do as a first step in any case. The errors will still be visible to client code and can be reported, allowing client code to fail more gracefully, as e.g. [substrate is doing by just disabling Mdns](https://github.com/paritytech/substrate/blob/9b08105b8c7106d723c4f470304ad9e2868569d9/client/network/src/discovery.rs#L812-L813), thereby logging the error. It would be great to get this into a patch release.